### PR TITLE
FEAT: 신규지원 관리자 리디렉션 및 인증 로직 추가

### DIFF
--- a/src/api/login.js
+++ b/src/api/login.js
@@ -1,56 +1,56 @@
-import client from './client';
-import useStore from '../store/userInformation';
+import client from "./client";
+import useStore from "../store/userInformation";
 
 // 수정 <- 수정완료 되면 삭제해주세요 !
 
 export async function postRefreshToken(email) {
-    try {
-        //refreshToken:"eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjE3NDE2MjIzMjF9.gklFT5rII3z1lUL5ztBEkDvpt7u2mL05NoetmMLRYX0",
-        //const refreshToken = Cookies.get("refreshToken");
-        const response = await client.post('/auth/refresh', {
-            email: email, // 이메일을 리프레시 토큰 발급 요청에 사용
-        });
-        return response;
-    } catch (error) {
-        return Promise.reject(error);
-    }
+  try {
+    //refreshToken:"eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjE3NDE2MjIzMjF9.gklFT5rII3z1lUL5ztBEkDvpt7u2mL05NoetmMLRYX0",
+    //const refreshToken = Cookies.get("refreshToken");
+    const response = await client.post("/auth/refresh", {
+      email: email, // 이메일을 리프레시 토큰 발급 요청에 사용
+    });
+    return response;
+  } catch (error) {
+    return Promise.reject(error);
+  }
 }
 
 export async function postLogin(email, password) {
-    try {
-        const response = await client.post('/auth/signin', {
-            email: email,
-            password: password,
-        });
-        // 로그인 성공 후 사용자 정보 zustand store에 저장
-        if (response.status === 200) {
-            const { user } = response.data.result; 
-            console.log('로그인 성공:', response.data.result);
-            useStore.getState().setUser(user); 
-        }
-
-        return response;
-    } catch (error) {
-        if (error.response && error.response.status === 400) {
-            return 400;
-        }
-        throw error;
+  try {
+    const response = await client.post("/auth/signin", {
+      email: email,
+      password: password,
+    });
+    // 로그인 성공 후 사용자 정보 zustand store에 저장
+    if (response.status === 200) {
+      const { user } = response.data.result;
+      console.log("로그인 성공:", response.data.result);
+      useStore.getState().setUser(user);
+      // 신규 지원 관리자에서 헤더에 사용자 이름을 표시해주기 위해서 추가
+      sessionStorage.setItem("username", response.data.result.username);
     }
+
+    return response;
+  } catch (error) {
+    if (error.response && error.response.status === 400) {
+      return 400;
+    }
+    throw error;
+  }
 }
 
 export async function getLogout() {
-    try {
-      const token = sessionStorage.getItem("access_token"); 
-      const response = await client.get("/auth/signout", null, {
-        headers: {
-          Authorization: token,
-        },
-      });
-      return response;
-    } catch (error) {
-      console.error("로그아웃 에러", error);
-      throw error;
-    }
-    
+  try {
+    const token = sessionStorage.getItem("access_token");
+    const response = await client.get("/auth/signout", null, {
+      headers: {
+        Authorization: token,
+      },
+    });
+    return response;
+  } catch (error) {
+    console.error("로그아웃 에러", error);
+    throw error;
   }
-  
+}

--- a/src/core/router.jsx
+++ b/src/core/router.jsx
@@ -16,6 +16,7 @@ import Study from "../pages/study";
 import Project from "../pages/project";
 import MemberList from "../pages/memberList";
 import WaitingList from "../pages/waitingList";
+import Apply from "../pages/apply";
 import { postRefreshToken } from "../api/login";
 
 function AppRouter() {
@@ -67,6 +68,7 @@ function AppRouter() {
         <Route path="/project" element={<Project />} />
         <Route path="/memberList" element={<MemberList />} />
         <Route path="/waitingList" element={<WaitingList />} />
+        <Route path="/apply" element={<Apply />} />
       </Routes>
     </>
   );

--- a/src/pages/apply.jsx
+++ b/src/pages/apply.jsx
@@ -1,0 +1,77 @@
+import { useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+export default function Apply() {
+  const navigate = useNavigate();
+  const iframeRef = useRef(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const handleMessage = (event) => {
+      // iframe 로드 완료 신호
+      if (event.data.type === "IFRAME_LOADED") {
+        setIsLoading(false);
+      }
+      if (event.data.type === "EXIT_FROM_APPLY_ADMIN") {
+        navigate("/session");
+      }
+    };
+
+    window.addEventListener("message", handleMessage);
+    return () => window.removeEventListener("message", handleMessage);
+  }, []);
+
+  const sendSessionInfo = () => {
+    if (!iframeRef.current) return;
+
+    const accessToken = sessionStorage.getItem("access_token");
+    const email = sessionStorage.getItem("email");
+    const username = sessionStorage.getItem("username");
+
+    if (!accessToken || !email) {
+      console.error("세션 정보가 없습니다.");
+      return;
+    }
+
+    const sessionData = {
+      type: "SESSION_DATA",
+      data: { accessToken, email, username },
+    };
+
+    iframeRef.current.contentWindow.postMessage(
+      sessionData,
+      "https://feat-api.d2hnz1q3fz81jx.amplifyapp.com"
+    );
+  };
+
+  const handleIframeLoad = () => {
+    setTimeout(() => {
+      sendSessionInfo();
+    }, 1000);
+  };
+
+  return (
+    <div className="relative min-h-screen bg-gray-100">
+      {/* 로딩 오버레이 */}
+      {isLoading && (
+        <div className="absolute inset-0 z-10 flex items-center justify-center bg-white bg-opacity-90">
+          <div className="text-center">
+            <div className="w-12 h-12 mx-auto mb-4 border-b-2 border-blue-500 rounded-full animate-spin"></div>
+            <p className="text-gray-600">서비스를 불러오는 중...</p>
+          </div>
+        </div>
+      )}
+
+      {/* iframe */}
+      <iframe
+        ref={iframeRef}
+        src="https://feat-api.d2hnz1q3fz81jx.amplifyapp.com"
+        className="w-full h-screen border-0"
+        onLoad={handleIframeLoad}
+        title="Apply Service"
+        allow="camera; microphone; geolocation"
+        sandbox="allow-same-origin allow-scripts allow-forms allow-popups allow-top-navigation"
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## 🛠️ 작업 내용

> 신규 지원 관리자를 위한 도메인 구매 비용도, 따로 로그인 페이지를 만들지 않고, 그대로 이어지길 바라셨기에 iframe (한 웹사이트에서 다른 사이트를 띄우는것)을 통해 서비스가 이어지도록 했습니다.

설명을 좀 드리자면 관리자에서 로그인 -> Apply 탭 클릭 -> 신규 지원 관리자를 iframe 태그로 띄움 -> 이와 동시에 관리자 페이지의 인증 정보를 iframe에게 전달 -> iframe에서 이를 저장 -> 저장하고 곧바로 리프레시 요청을 날려 신규 지원 관리자에서 그대로 인증이 이어짐

이러한 과정이 있다보면 중간에 신규 지원 관리자를 띄울때 로딩창을 삽입했고, 서비스 이동에 시간이 좀 걸리긴 하지만 (한 2초~3초?) 현재로서는 이게 최선이라서 어쩔 수 없었습니다.
배포도 원래는 S3 이용해서 해볼려고 했는데 신규 지원 관리자의 경우, 도메인 구매할수도 없는 상황인데, https도 필요하고 해서 
배포는 aws amplify로 진행했습니다. (가장 쉽고 확실해서)

