### PR TITLE
FIX : 헤더 리다이렉트 해결

### DIFF
--- a/src/components/header.jsx
+++ b/src/components/header.jsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useLocation, useNavigate } from "react-router-dom";
+import { useLocation, useNavigate, Link } from "react-router-dom";
 import { getLogout } from "../api/login";
 import useStore from "../store/userInformation";
 
@@ -70,18 +70,18 @@ export default function Header() {
       className="fixed top-0 left-0 w-full z-50 flex items-center justify-between py-6 px-[72px]
                 bg-gradient-to-b from-black from-25% to-transparent"
     >
-      <img src={TaveLogo} alt="Logo" className="w-25 cursor-pointer" onClick={() => window.location.href = "/session"}/>
+      <img src={TaveLogo} alt="Logo" className="w-25 cursor-pointer" onClick={() => navigate("/session")}/>
       <ul className="flex items-center gap-x-4 text-white text-xl">
         {navItems.map(({ path, label }) => (
           <li key={label} className="py-2 px-4 font-bold">
-            <a
-              href={path}
+            <Link
+              to={path}
               className={`cursor-pointer ${
                 isActive(path) ? "text-[#195bff]" : ""
               }`}
             >
               {label}
-            </a>
+            </Link>
           </li>
         ))}
         <li


### PR DESCRIPTION
## 🔗 연관된 이슈

> 이슈 번호를 적어 주세요.

## 🛠️ 작업 내용

> 헤더에서 어떤 요소를 클릭해도 로그인 페이지로 리다이렉트되는 문제 해결

1. Link 컴포넌트 import: react-router-dom에서 Link를 추가로 import
2. href를 to로 변경: <a href={path}>를 <Link to={path}>로 변경
3. 로고 클릭 수정: **window.location.href를 navigate()로 변경**

기존 `window.location.href` 만 사용하려 했으나, `navigate`를 사용하여 수정했습니다.

## 📸 스크린샷 (선택)

## 💬 리뷰 요구사항 (선택)

> `navigate`를 사용없이 수정할 수 있으면 반영부탁드립니다.
